### PR TITLE
Concurrent fibers

### DIFF
--- a/lib/cli.rb
+++ b/lib/cli.rb
@@ -29,6 +29,15 @@ class MyCLI < Thor
       end
     end
 
+    Fiber.schedule do
+      loop do
+        puts "this one runs every 15s"
+        t0 = Time.now
+        sleep 15
+        puts "woke up after #{Time.now - t0} seconds"
+      end
+    end
+
     puts "Fiber scheduled at #{Time.now} (control returns to the scheduler)"
   end
 

--- a/lib/cli.rb
+++ b/lib/cli.rb
@@ -24,7 +24,7 @@ class MyCLI < Thor
         puts "ran the updater, sleeping now"
         t0 = Time.now
 
-        sleep 14400 # 4*60*60
+        sleep 40 # 4*60*60
         puts "woke up after #{Time.now - t0} seconds"
       end
     end

--- a/lib/cli.rb
+++ b/lib/cli.rb
@@ -32,8 +32,9 @@ class MyCLI < Thor
     Fiber.schedule do
       loop do
         t0 = Time.now
-        sleep 60 # * 60
-        puts "heartbeat every #{(Time.now - t0) / 60.0} minute(s)"
+        sleep 60 * 60
+        how_long = (Time.now - t0) / 60.0
+        puts "heartbeat every #{how_long.round}m"
       end
     end
 

--- a/lib/cli.rb
+++ b/lib/cli.rb
@@ -24,17 +24,16 @@ class MyCLI < Thor
         puts "ran the updater, sleeping now"
         t0 = Time.now
 
-        sleep 40 # 4*60*60
-        puts "woke up after #{Time.now - t0} seconds"
+        sleep 14400 # 4*60*60
+        puts "updater running again after #{Time.now - t0} seconds"
       end
     end
 
     Fiber.schedule do
       loop do
-        puts "this one runs every 15s"
         t0 = Time.now
-        sleep 15
-        puts "woke up after #{Time.now - t0} seconds"
+        sleep 60 # * 60
+        puts "heartbeat every #{(Time.now - t0) / 60.0} minute(s)"
       end
     end
 

--- a/lib/cli.rb
+++ b/lib/cli.rb
@@ -37,7 +37,7 @@ class MyCLI < Thor
       end
     end
 
-    puts "Fiber scheduled at #{Time.now} (control returns to the scheduler)"
+    puts "MyCLI::sync scheduled Fibers at #{Time.now}" # + " and yields to libev"
   end
 
   no_commands {


### PR DESCRIPTION
What fun is concurrency with just one fiber? Add a heartbeat

Since we know this process downloads 144kb, it's expensive enough to warrant running it not more frequently than once every 4 hours. (Maybe we should run it even less frequently than that.)

It would be good if we got log messages a bit more frequently so that we know the scheduler hasn't croaked