### PR TITLE
Resolve fresh data fails to refresh

### DIFF
--- a/lib/bee_service.rb
+++ b/lib/bee_service.rb
@@ -10,6 +10,14 @@ class BeeService
     @username = username
     @access_token = access_token
     @json_filename = json_filename
+
+    do_lifting
+  end
+
+  def do_lifting
+    @json = nil
+    @json_data = nil
+
     @json_data = File.read(json_filename)
 
     validate_json
@@ -55,6 +63,12 @@ class BeeService
     `#{cmd}`
   end
 
+  # JSON is considered fresh if it has an mtime in 10 seconds recent history
+  def fresh_json_data?
+    mtime = File.mtime(json_filename)
+    Time.now - mtime < 10
+  end
+
   private
     def validate_json
       if json.class.to_s == "Hash"
@@ -75,12 +89,6 @@ class BeeService
     end
     def json
       @json ||= JSON.parse(json_data)
-    end
-
-    # JSON is considered fresh if it has an mtime in 10 seconds recent history
-    def fresh_json_data?
-      mtime = File.mtime(json_filename)
-      Time.now - mtime < 10
     end
 
     def comment_matcher

--- a/lib/bee_service.rb
+++ b/lib/bee_service.rb
@@ -19,6 +19,7 @@ class BeeService
     @json_data = nil
 
     @json_data = File.read(json_filename)
+    @last_read = Time.now
 
     validate_json
   end
@@ -63,13 +64,17 @@ class BeeService
     `#{cmd}`
   end
 
-  # JSON is considered fresh if it has an mtime in 10 seconds recent history
-  def fresh_json_data?
-    mtime = File.mtime(json_filename)
-    Time.now - mtime < 10
+  def fresh_read?
+    Time.now - @last_read < 10
   end
 
   private
+    # JSON is considered fresh if it has an mtime in 10 seconds recent history
+    def fresh_json_data?
+      mtime = File.mtime(json_filename)
+      Time.now - mtime < 10
+    end
+
     def validate_json
       if json.class.to_s == "Hash"
         status = json["status"]

--- a/lib/cli.rb
+++ b/lib/cli.rb
@@ -87,8 +87,13 @@ class MyCLI < Thor
       # The old standby shell-out still works here though!
       `./README`
 
-      init_bee
+      hit_up_beeminder_json
       @user.update(beeminder)
+    end
+
+    def hit_up_beeminder_json
+      @bee_service = init_bee
+      @bee_service.do_lifting unless @bee_service.fresh_json_data?
     end
 
     def self.start(args)

--- a/lib/cli.rb
+++ b/lib/cli.rb
@@ -93,7 +93,7 @@ class MyCLI < Thor
 
     def hit_up_beeminder_json
       @bee_service = init_bee
-      @bee_service.do_lifting unless @bee_service.fresh_json_data?
+      @bee_service.do_lifting unless @bee_service.fresh_read?
     end
 
     def self.start(args)


### PR DESCRIPTION
We are running the script to fetch simplest-commitbee.json every time, but we are not reading the file again from disk.

Freshness of 10s is presumed to be fresh enough, (we should only be reading the file once every 10s as a rate limit.)

This is not the expensive part, the fetch is the expensive part, but since the whole sync operation blocks on both the fetch and the read, it's safe to put that rate limit here (and it definitely won't come back to bite me in the ass!)

**checks behind self** Yeah it'll be fine...