### PR TITLE
Fixup fails to refresh Commits-to API

### DIFF
--- a/lib/cli.rb
+++ b/lib/cli.rb
@@ -87,8 +87,13 @@ class MyCLI < Thor
       # The old standby shell-out still works here though!
       `./README`
 
+      hit_up_commitsto_api
       hit_up_beeminder_json
       @user.update(beeminder)
+    end
+
+    def hit_up_commitsto_api
+      set_user(username: 'kb')
     end
 
     def hit_up_beeminder_json


### PR DESCRIPTION
Just call and get a new instance of the commit_factory

(This is messy)

Without this change we are publishing duplicates as long as the service runs :\